### PR TITLE
Environmental variables for workdir and libpath

### DIFF
--- a/runApp.r
+++ b/runApp.r
@@ -1,5 +1,7 @@
-setwd("/home/esuarez/bioregistros/bioregistros-app")
-.libPaths("/home/esuarez/R")
+WD <- Sys.getenv("WORK_DIR")
+LP <- Sys.getenv("LIB_PATH")
+setwd(WD)
+.libPaths(LP)
 list.of.packages <- c("shiny", "shinyFiles", "data.table", "rgdal", "sf", "dplyr", "stringi")
 new.packages <- list.of.packages[!(list.of.packages %in% installed.packages()[,"Package"])]
 if(length(new.packages)) install.packages(new.packages, repos = "http://cran.us.r-project.org")

--- a/runApp.r
+++ b/runApp.r
@@ -1,7 +1,11 @@
 WD <- Sys.getenv("WORK_DIR")
 LP <- Sys.getenv("LIB_PATH")
-setwd(WD)
-.libPaths(LP)
+if (WD != "") {
+  setwd(WD)
+}
+if (LP != "") {
+  .libPaths(LP)
+}
 list.of.packages <- c("shiny", "shinyFiles", "data.table", "rgdal", "sf", "dplyr", "stringi")
 new.packages <- list.of.packages[!(list.of.packages %in% installed.packages()[,"Package"])]
 if(length(new.packages)) install.packages(new.packages, repos = "http://cran.us.r-project.org")


### PR DESCRIPTION
Set the env vars: `WORK_DIR` and `LIB_PATH` before running the app or it will use default values.

Or, from the command line execute like this:
`WORK_DIR=absolute_path LIB_PATH=lib_path Rscript runApp.r`